### PR TITLE
Add more customization of the pipeline

### DIFF
--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -15,6 +15,9 @@ default:
   fit_signal_model:
     # signal model covariate model settings, contains configurations of the spline and its priors
     cov_model:
+      # type of the cov model, here we only have two options 'linear' or 'log'
+      # please use 'log' when you are dealing with log relative risk, otherwise you can use 'linear' when see fit
+      type: "log"
       # the value of these knots won't be used in the actual model fitting, but the number of knots will be used
       # the actual values of the knots will be sampled using the settings in "knots_samples"
       spline_knots: [0.0, 0.25, 0.5, 0.75, 1.0]

--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -12,6 +12,12 @@ diet_veg-cvd_ihd:
 default:
   # random seed
   seed: 0
+  # data description
+  data:
+    obs: "ln_rr"
+    obs_se: "ln_rr_se"
+    study_id: "study_id"
+    data_id: "seq"
   fit_signal_model:
     # signal model covariate model settings, contains configurations of the spline and its priors
     cov_model:

--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -46,6 +46,10 @@ default:
     signal_model:
       # trimming settings, inlier percentage default to be 90%, if you don't want to trim, use 1.0
       inlier_pct: 0.9
+    # settings for the optimizer
+    fit_model:
+      outer_step_size: 200
+      outer_max_iter: 100
   select_bias_covs:
     # settings for covariate selection
     cov_finder:

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -57,15 +57,19 @@ def fit_signal_model(dataif: DataInterface) -> None:
     df = dataif.load_result(f"{name}.csv")
 
     all_settings = dataif.load_result("settings.yaml")
+    settings = all_settings["fit_signal_model"]
 
     signal_model = functions.get_signal_model(all_settings, df)
-    signal_model.fit_model(outer_step_size=200, outer_max_iter=100)
+    signal_model.fit_model(**{
+        **dict(outer_step_size=200, outer_max_iter=100),
+        **settings.get("fit_model", {}),
+    })
 
     df = functions.convert_bc_to_em(df, signal_model)
 
     summary = functions.get_signal_model_summary(name, all_settings, df)
 
-    fig = functions.plot_signal_model(name, summary, df, signal_model)
+    fig = functions.plot_signal_model(name, all_settings, summary, df, signal_model)
 
     dataif.dump_result(df, f"{name}.csv")
     dataif.dump_result(signal_model, "signal_model.pkl")
@@ -137,7 +141,7 @@ def fit_linear_model(dataif: DataInterface) -> None:
     linear_model.fit_model()
 
     summary = functions.get_linear_model_summary(
-        settings,
+        all_settings,
         summary,
         df,
         signal_model,
@@ -152,7 +156,7 @@ def fit_linear_model(dataif: DataInterface) -> None:
         settings, summary, signal_model
     )
 
-    fig = functions.plot_linear_model(name, summary, df, signal_model, linear_model)
+    fig = functions.plot_linear_model(name, all_settings, summary, df, signal_model, linear_model)
 
     dataif.dump_result(linear_model, "linear_model.pkl")
     dataif.dump_result(summary, "summary.yaml")

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -57,9 +57,8 @@ def fit_signal_model(dataif: DataInterface) -> None:
     df = dataif.load_result(f"{name}.csv")
 
     all_settings = dataif.load_result("settings.yaml")
-    settings = all_settings["fit_signal_model"]
 
-    signal_model = functions.get_signal_model(settings, df)
+    signal_model = functions.get_signal_model(all_settings, df)
     signal_model.fit_model(outer_step_size=200, outer_max_iter=100)
 
     df = functions.convert_bc_to_em(df, signal_model)
@@ -94,7 +93,7 @@ def select_bias_covs(dataif: DataInterface) -> None:
     all_settings = dataif.load_result("settings.yaml")
     settings = all_settings["select_bias_covs"]
 
-    cov_finder_linear_model = functions.get_cov_finder_linear_model(df)
+    cov_finder_linear_model = functions.get_cov_finder_linear_model(all_settings, df)
     cov_finder_linear_model.fit_model()
 
     cov_finder = functions.get_cov_finder(settings, cov_finder_linear_model)
@@ -134,7 +133,7 @@ def fit_linear_model(dataif: DataInterface) -> None:
     summary = dataif.load_result("summary.yaml")
     signal_model = dataif.load_result("signal_model.pkl")
 
-    linear_model = functions.get_linear_model(df_train, cov_finder_result)
+    linear_model = functions.get_linear_model(all_settings, df_train, cov_finder_result)
     linear_model.fit_model()
 
     summary = functions.get_linear_model_summary(

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -43,6 +43,7 @@ def get_signal_model(settings: dict, df: DataFrame) -> MRBeRT:
     )
     settings["cov_model"] = {
         **dict(
+            type="log",
             use_re=False,
             use_spline=True,
             prior_spline_funval_uniform=[-0.999999, 19],
@@ -50,7 +51,17 @@ def get_signal_model(settings: dict, df: DataFrame) -> MRBeRT:
         ),
         **settings["cov_model"],
     }
-    cov_model = LogCovModel(
+    type_name = settings["cov_model"].pop("type")
+    if type_name == "log":
+        type_class = LogCovModel
+    elif type_name == "linear":
+        type_class = LinearCovModel
+    else:
+        raise TypeError(
+            f"Unrecognized cov_model type='{type_name}', "
+             "can only choose from 'log' or 'linear'"
+        )
+    cov_model = type_class(
         alt_cov=["alt_risk_lower", "alt_risk_upper"],
         ref_cov=["ref_risk_lower", "ref_risk_upper"],
         **settings["cov_model"],

--- a/src/bopforge/dichotomous_pipeline/__main__.py
+++ b/src/bopforge/dichotomous_pipeline/__main__.py
@@ -65,8 +65,11 @@ def fit_signal_model(result_folder: Path) -> None:
     all_settings = dataif.load_result("settings.yaml")
     settings = all_settings["fit_signal_model"]
 
-    signal_model = functions.get_signal_model(settings, df)
-    signal_model.fit_model(outer_step_size=200, outer_max_iter=100)
+    signal_model = functions.get_signal_model(all_settings, df)
+    signal_model.fit_model(**{
+        **dict(outer_step_size=200, outer_max_iter=100),
+        **settings.get("fit_model", {}),
+    })
 
     df = functions.add_cols(df, signal_model)
 
@@ -136,16 +139,16 @@ def fit_linear_model(result_folder: Path) -> None:
     settings = all_settings["complete_summary"]
     summary = dataif.load_result("summary.yaml")
 
-    linear_model = functions.get_linear_model(df_train, cov_finder_result)
+    linear_model = functions.get_linear_model(all_settings, df_train, cov_finder_result)
     linear_model.fit_model()
 
-    summary = functions.get_linear_model_summary(summary, df, linear_model)
+    summary = functions.get_linear_model_summary(all_settings, summary, df, linear_model)
 
     df_inner_draws, df_outer_draws = functions.get_draws(settings, summary)
 
     df_inner_quantiles, df_outer_quantiles = functions.get_quantiles(settings, summary)
 
-    fig = functions.plot_linear_model(summary, df)
+    fig = functions.plot_linear_model(all_settings, summary, df)
 
     dataif.dump_result(linear_model, "linear_model.pkl")
     dataif.dump_result(summary, "summary.yaml")

--- a/src/bopforge/dichotomous_pipeline/functions.py
+++ b/src/bopforge/dichotomous_pipeline/functions.py
@@ -465,7 +465,7 @@ def _plot_funnel(all_settings: dict, summary: dict, df: DataFrame, ax: Axes) -> 
     )
 
     # set title and labels
-    ax.set_xlabel("ln_rr")
-    ax.set_ylabel("ln_rr_se")
+    ax.set_xlabel(data_settings["obs"])
+    ax.set_ylabel(data_settings["obs_se"])
 
     return ax

--- a/src/bopforge/utils.py
+++ b/src/bopforge/utils.py
@@ -2,7 +2,7 @@
 Ultility functions
 """
 import argparse
-from typing import Any, Dict, Tuple, Optional
+from typing import Dict, Tuple, Optional
 
 import numpy as np
 from mrtool import MRBRT, MRBeRT, MRData


### PR DESCRIPTION
* Add `type` option under `cov_model` in continuous pipeline `fit_signal_model` section, allow both `'log'` and `'linear'` in case we aren't deal with log relative risk
* Add `data` section including customized data column name, so that user don't need to stick with the name we set
* Add `fit_model` options for the `fit_signal_model` section, in case user want to control the settings for the optimizer to speed things up