### PR TITLE
0.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bopforge"
-version = "0.0.4"
+version = "0.0.5"
 description = "Pipelines for Burden of Proof (BoP) analyses"
 readme = "REDME.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },
 ]
-dependencies = ["numpy", "scipy", "pandas", "matplotlib", "mrtool", "pplkit"]
+dependencies = ["numpy", "scipy", "pandas", "matplotlib", "mrtool==0.1.4", "pplkit"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -26,8 +26,8 @@ def pre_processing(dataif: DataInterface) -> None:
     df.drop(columns=covs_to_remove, inplace=True)
 
     # remove from settings
-    all_covs = set(all_covs)
-    covs_to_remove = set(covs_to_remove)
+    all_covs = set("em" + col[3:] for col in all_covs)
+    covs_to_remove = set("em" + col[3:] for col in covs_to_remove)
     pre_selected_covs = set(settings["pre_selected_covs"])
     pre_selected_covs = pre_selected_covs & all_covs
     pre_selected_covs = pre_selected_covs - covs_to_remove


### PR DESCRIPTION
Fix the bug regarding the `pre_selected_covs` parameter. Due to the inconsistency of naming between `cov_` and `em_`, we accidentally remove all the `pre_selected_covs` from user provided list. In this PR and new version, we fixed it, however, it will probably be better if we have more consistent naming.