### PR TITLE
Pipeline action

### DIFF
--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -52,6 +52,7 @@ def fit_signal_model(dataif: DataInterface) -> None:
         Data interface in charge of file reading and writing.
 
     """
+    pre_processing(dataif)
     name = dataif.result.name
 
     df = dataif.load_result(f"{name}.csv")
@@ -214,7 +215,6 @@ def run(
 
         np.random.seed(pair_settings["seed"])
         pair_dataif = DataInterface(result=pair_o_dir)
-        pre_processing(pair_dataif)
         for action in actions:
             globals()[action](pair_dataif)
 

--- a/src/bopforge/dichotomous_pipeline/__main__.py
+++ b/src/bopforge/dichotomous_pipeline/__main__.py
@@ -55,6 +55,7 @@ def fit_signal_model(result_folder: Path) -> None:
         Data interface in charge of file reading and writing.
 
     """
+    pre_processing(result_folder)
     dataif = DataInterface(result=result_folder)
     name = dataif.result.name
 
@@ -204,7 +205,6 @@ def run(
         dataif.dump_o_dir(pair_settings, pair, "settings.yaml")
 
         np.random.seed(pair_settings["seed"])
-        pre_processing(pair_o_dir)
         for action in actions:
             globals()[action](pair_o_dir)
 


### PR DESCRIPTION
In the PR, we try to address issues:

When directly running `fit_linear_model` action, the `pre_process` function will still be triggered and the results from the signal model will be erased.

**Solution**: make `pre_process` function as part of `fit_signal_model` function, so that it will only be called when `fit_signal_model` is called.