### PR TITLE
Make plot consistent and adding options

### DIFF
--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -60,4 +60,7 @@ default:
       # for monotonic curve this is usually false
       # only for j-shaped this can be true
       normalize_to_tmrel: false
+  figure:
+    # if we want to show the connection between the reference and alternative exposure
+    show_ref: false
 

--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -62,5 +62,5 @@ default:
       normalize_to_tmrel: false
   figure:
     # if we want to show the connection between the reference and alternative exposure
-    show_ref: false
+    show_ref: true
 

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -67,7 +67,13 @@ def fit_signal_model(dataif: DataInterface) -> None:
 
     summary = functions.get_signal_model_summary(name, all_settings, df)
 
-    fig = functions.plot_signal_model(name, summary, df, signal_model)
+    fig = functions.plot_signal_model(
+        name,
+        summary,
+        df,
+        signal_model,
+        show_ref=all_settings["figure"]["show_ref"],
+    )
 
     dataif.dump_result(df, f"{name}.csv")
     dataif.dump_result(signal_model, "signal_model.pkl")
@@ -154,7 +160,14 @@ def fit_linear_model(dataif: DataInterface) -> None:
         settings, summary, signal_model
     )
 
-    fig = functions.plot_linear_model(name, summary, df, signal_model, linear_model)
+    fig = functions.plot_linear_model(
+        name,
+        summary,
+        df,
+        signal_model,
+        linear_model,
+        show_ref=all_settings["figure"]["show_ref"],
+    )
 
     dataif.dump_result(linear_model, "linear_model.pkl")
     dataif.dump_result(summary, "summary.yaml")

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -563,7 +563,11 @@ def get_quantiles(
 
 
 def plot_signal_model(
-    name: str, summary: dict, df: DataFrame, signal_model: MRBeRT
+    name: str,
+    summary: dict,
+    df: DataFrame,
+    signal_model: MRBeRT,
+    show_ref: bool = True,
 ) -> Figure:
     """Plot the signal model
 
@@ -577,6 +581,8 @@ def plot_signal_model(
         Data frame contains training data.
     signal_model
         Fitted signal model for risk curve.
+    show_ref
+        Whether to show the reference line. Default is `True`.
 
     Returns
     -------
@@ -588,7 +594,7 @@ def plot_signal_model(
     fig, ax = plt.subplots(figsize=(8, 5))
 
     # plot data
-    _plot_data(name, summary, df, ax, signal_model=signal_model)
+    _plot_data(name, summary, df, ax, signal_model=signal_model, show_ref=show_ref)
 
     # plot curve
     risk = np.linspace(*summary["risk_bounds"], 100)
@@ -606,6 +612,7 @@ def plot_linear_model(
     df: DataFrame,
     signal_model: MRBeRT,
     linear_model: MRBRT,
+    show_ref: bool = True,
 ) -> Figure:
     """Plot the linear model
 
@@ -621,6 +628,8 @@ def plot_linear_model(
         Fitted signal model for risk curve.
     linear_model
         Fitted linear model for risk curve.
+    show_ref
+        Whether to show the reference line. Default is `True`.
 
     Returns
     -------
@@ -632,7 +641,7 @@ def plot_linear_model(
     fig, ax = plt.subplots(1, 2, figsize=(16, 5))
 
     # plot data
-    _plot_data(name, summary, df, ax[0], signal_model, linear_model)
+    _plot_data(name, summary, df, ax[0], signal_model, linear_model, show_ref=show_ref)
 
     # plot curve and uncertainty
     beta = summary["beta"]
@@ -679,6 +688,7 @@ def _plot_data(
     ax: Axes,
     signal_model: MRBeRT = None,
     linear_model: Optional[MRBRT] = None,
+    show_ref: bool = True,
 ) -> Axes:
     """Plot data points
 
@@ -697,6 +707,8 @@ def _plot_data(
         the points are plotted reference to original signal model. When linear
         model is provided, the points are plotted reference to the linear model
         risk curve.
+    show_ref
+        Whether to show the reference line. Default is `True`.
 
     Returns
     -------
@@ -748,8 +760,9 @@ def _plot_data(
         alpha=0.5,
         marker="x",
     )
-    for x_0, y_0, x_1, y_1 in zip(alt_risk, alt_ln_rr, ref_risk, ref_ln_rr):
-        ax.plot([x_0, x_1], [y_0, y_1], color="#008080", linewidth=0.5, alpha=0.5)
+    if show_ref:
+        for x_0, y_0, x_1, y_1 in zip(alt_risk, alt_ln_rr, ref_risk, ref_ln_rr):
+            ax.plot([x_0, x_1], [y_0, y_1], color="#008080", linewidth=0.5, alpha=0.5)
 
     # plot support lines
     ax.axhline(0.0, linewidth=1, linestyle="-", color="gray")

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -646,11 +646,11 @@ def plot_linear_model(
     pred = np.outer(
         np.array(
             [
-                beta[0] - 1.645 * outer_beta_sd,
-                beta[0] - 1.645 * inner_beta_sd,
+                beta[0] - 1.96 * outer_beta_sd,
+                beta[0] - 1.96 * inner_beta_sd,
                 beta[0],
-                beta[0] + 1.645 * inner_beta_sd,
-                beta[0] + 1.645 * outer_beta_sd,
+                beta[0] + 1.96 * inner_beta_sd,
+                beta[0] + 1.96 * outer_beta_sd,
             ]
         ),
         signal,
@@ -659,9 +659,12 @@ def plot_linear_model(
     if summary["normalize_to_tmrel"]:
         pred -= pred[:, [np.argmin(pred[2])]]
 
+    log_bprf = pred[2] * (1.0 - 1.645 * outer_beta_sd / beta[0])
+
     ax[0].plot(risk, pred[2], color="#008080")
     ax[0].fill_between(risk, pred[0], pred[4], color="gray", alpha=0.2)
     ax[0].fill_between(risk, pred[1], pred[3], color="gray", alpha=0.2)
+    ax[0].plot(risk, log_bprf, color="red")
 
     # plot funnel
     _plot_funnel(summary, df, ax[1])


### PR DESCRIPTION
1. Plot the 95% CI and the burden of proof function to be consistent with publication figure
2. Add option to remove connection between the alternative and reference exposures

Original plot
<img width="597" alt="Screenshot 2024-02-12 at 4 26 23 PM" src="https://github.com/ihmeuw-msca/bopforge/assets/10691492/a3718180-7dfc-4f52-8745-d9ba1c63ee4c">

95% CI and BPRF
<img width="600" alt="Screenshot 2024-02-12 at 4 27 51 PM" src="https://github.com/ihmeuw-msca/bopforge/assets/10691492/06ef8d76-e38e-4b53-8290-982a8f5c8d20">

Option to remove connection
<img width="595" alt="Screenshot 2024-02-12 at 4 28 36 PM" src="https://github.com/ihmeuw-msca/bopforge/assets/10691492/de66203d-1a46-4035-8c08-eb9504a6aaf4">

