### PR TITLE
Add star rating to summary file

### DIFF
--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -383,7 +383,7 @@ def get_linear_model_summary(
     summary["beta"] = [float(beta_info[0]), float(beta_info[1])]
     summary["gamma"] = [float(gamma_info[0]), float(gamma_info[1])]
 
-    # compute the score
+    # compute the score and add star rating
     risk = np.linspace(*summary["risk_bounds"], 100)
     signal = get_signal(signal_model, risk)
     beta_sd = np.sqrt(beta_info[1] ** 2 + gamma_info[0] + 2 * gamma_info[1])
@@ -412,10 +412,25 @@ def get_linear_model_summary(
     sign = np.sign(pred)
     if np.any(np.prod(inner_ui[:, index], axis=0) < 0):
         summary["score"] = float("nan")
+        summary["star_rating"] = 0
     else:
-        summary["score"] = float(
+        score = float(
             ((sign * burden_of_proof)[:, index].mean(axis=1)).min()
         )
+        summary["score"] = score
+        #Assign star rating based on ROS
+        if np.isnan(score):
+            summary["star_rating"] = 0
+        elif score > 0.6152:
+            summary["star_rating"] = 5
+        elif score > 0.4055:
+            summary["star_rating"] = 4
+        elif score > 0.1398:
+            summary["star_rating"] = 3
+        elif score > 0:
+            summary["star_rating"] = 2
+        else:
+            summary["star_rating"] = 1
 
     # compute the publication bias
     index = df.is_outlier == 0

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -421,11 +421,11 @@ def get_linear_model_summary(
         #Assign star rating based on ROS
         if np.isnan(score):
             summary["star_rating"] = 0
-        elif score > 0.6152:
+        elif score > np.log(1 + 0.85):
             summary["star_rating"] = 5
-        elif score > 0.4055:
+        elif score > np.log(1 + 0.50):
             summary["star_rating"] = 4
-        elif score > 0.1398:
+        elif score > np.log(1 + 0.15):
             summary["star_rating"] = 3
         elif score > 0:
             summary["star_rating"] = 2

--- a/src/bopforge/dichotomous_pipeline/functions.py
+++ b/src/bopforge/dichotomous_pipeline/functions.py
@@ -250,11 +250,11 @@ def get_linear_model_summary(
         #Assign star rating based on ROS
         if np.isnan(score):
             summary["star_rating"] = 0
-        elif score > 0.6152:
+        elif score > np.log(1 + 0.85):
             summary["star_rating"] = 5
-        elif score > 0.4055:
+        elif score > np.log(1 + 0.50):
             summary["star_rating"] = 4
-        elif score > 0.1398:
+        elif score > np.log(1 + 0.15):
             summary["star_rating"] = 3
         elif score > 0:
             summary["star_rating"] = 2

--- a/src/bopforge/dichotomous_pipeline/functions.py
+++ b/src/bopforge/dichotomous_pipeline/functions.py
@@ -235,7 +235,7 @@ def get_linear_model_summary(
     summary["beta"] = [float(beta_info[0]), float(beta_info[1])]
     summary["gamma"] = [float(gamma_info[0]), float(gamma_info[1])]
 
-    # compute the score
+    # compute the score and add star rating
     beta_sd = np.sqrt(beta_info[1] ** 2 + gamma_info[0] + 2 * gamma_info[1])
     sign = np.sign(beta_info[0])
     inner_ui = beta_info[0] - sign * 1.96 * beta_info[1]
@@ -243,8 +243,23 @@ def get_linear_model_summary(
 
     if inner_ui * beta_info[0] < 0:
         summary["score"] = float("nan")
+        summary["star_rating"] = 0
     else:
-        summary["score"] = float(0.5 * sign * burden_of_proof)
+        score = float(0.5 * sign * burden_of_proof)
+        summary["score"] = score
+        #Assign star rating based on ROS
+        if np.isnan(score):
+            summary["star_rating"] = 0
+        elif score > 0.6152:
+            summary["star_rating"] = 5
+        elif score > 0.4055:
+            summary["star_rating"] = 4
+        elif score > 0.1398:
+            summary["star_rating"] = 3
+        elif score > 0:
+            summary["star_rating"] = 2
+        else:
+            summary["star_rating"] = 1
 
     # compute the publication bias
     index = df.is_outlier == 0


### PR DESCRIPTION
Adds corresponding star rating based on the risk-outcome score to the `summary.yaml` file for both continuous and dichotomous pipelines.

Bounds in the ROS for the star rating are currently hard-coded; if there is a way to encode these that doesn't require the actual numeric values, that might be a nice, more flexible alternative.

If you have any suggestions for making this more efficient or if you spot anything in error, please let me know!

Snippet of summary for continuous and dichotomous test pairs with new `star_rating` output:
<img width="242" alt="Screenshot 2024-02-14 at 11 23 11 AM" src="https://github.com/ihmeuw-msca/bopforge/assets/148926375/cd42d06f-9bbf-4067-8fd4-adea9842146e">

<img width="251" alt="Screenshot 2024-02-14 at 11 30 28 AM" src="https://github.com/ihmeuw-msca/bopforge/assets/148926375/0d46d7e1-e8de-4683-a26f-7ad8851993e7">

