### PR TITLE
Update to version 0.0.6

### DIFF
--- a/data/continuous/settings.yaml
+++ b/data/continuous/settings.yaml
@@ -60,4 +60,7 @@ default:
       # for monotonic curve this is usually false
       # only for j-shaped this can be true
       normalize_to_tmrel: false
+  figure:
+    # if we want to show the connection between the reference and alternative exposure
+    show_ref: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bopforge"
-version = "0.0.5"
+version = "0.0.6"
 description = "Pipelines for Burden of Proof (BoP) analyses"
 readme = "REDME.md"
 requires-python = ">=3.10"
@@ -28,5 +28,5 @@ dichotomous_pipeline = "bopforge.dichotomous_pipeline.__main__:main"
 [tool.sphinx]
 project = "modrover"
 author = "IHME Math Sciences"
-copyright = "2023, IHME Math Sciences"
-version = "0.0.4"
+copyright = "2024, IHME Math Sciences"
+version = "0.0.6"

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -52,6 +52,7 @@ def fit_signal_model(dataif: DataInterface) -> None:
         Data interface in charge of file reading and writing.
 
     """
+    pre_processing(dataif)
     name = dataif.result.name
 
     df = dataif.load_result(f"{name}.csv")
@@ -214,7 +215,6 @@ def run(
 
         np.random.seed(pair_settings["seed"])
         pair_dataif = DataInterface(result=pair_o_dir)
-        pre_processing(pair_dataif)
         for action in actions:
             globals()[action](pair_dataif)
 

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -67,7 +67,13 @@ def fit_signal_model(dataif: DataInterface) -> None:
 
     summary = functions.get_signal_model_summary(name, all_settings, df)
 
-    fig = functions.plot_signal_model(name, summary, df, signal_model)
+    fig = functions.plot_signal_model(
+        name,
+        summary,
+        df,
+        signal_model,
+        show_ref=all_settings["figure"]["show_ref"],
+    )
 
     dataif.dump_result(df, f"{name}.csv")
     dataif.dump_result(signal_model, "signal_model.pkl")
@@ -154,7 +160,14 @@ def fit_linear_model(dataif: DataInterface) -> None:
         settings, summary, signal_model
     )
 
-    fig = functions.plot_linear_model(name, summary, df, signal_model, linear_model)
+    fig = functions.plot_linear_model(
+        name,
+        summary,
+        df,
+        signal_model,
+        linear_model,
+        show_ref=all_settings["figure"]["show_ref"],
+    )
 
     dataif.dump_result(linear_model, "linear_model.pkl")
     dataif.dump_result(summary, "summary.yaml")

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -171,18 +171,14 @@ def get_signal_model_summary(name: str, all_settings: dict, df: DataFrame) -> di
         "risk_unit": str(df.risk_unit.values[0]),
     }
     summary["risk_bounds"] = [float(risk_exposures.min()), float(risk_exposures.max())]
-    ref_risk = risk_exposures[:, [0, 1]]
-    alt_risk = risk_exposures[:, [2, 3]]
-    if ref_risk.mean() <= alt_risk.mean():
-        summary["risk_score_bounds"] = [
-            float(np.quantile(ref_risk.mean(axis=1), 0.15)),
-            float(np.quantile(alt_risk.mean(axis=1), 0.85)),
-        ]
-    else:
-        summary["risk_score_bounds"] = [
-            float(np.quantile(alt_risk.mean(axis=1), 0.15)),
-            float(np.quantile(ref_risk.mean(axis=1), 0.85)),
-        ]
+    risk_mean = np.vstack(
+        [risk_exposures[:, [0, 1]].mean(axis=1), risk_exposures[:, [2, 3]].mean(axis=1)]
+    )
+    risk_mean.sort(axis=0)
+    summary["risk_score_bounds"] = [
+        float(np.quantile(risk_mean[0], 0.15)),
+        float(np.quantile(risk_mean[1], 0.85)),
+    ]
     summary["normalize_to_tmrel"] = all_settings["complete_summary"]["score"][
         "normalize_to_tmrel"
     ]

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -383,7 +383,7 @@ def get_linear_model_summary(
     summary["beta"] = [float(beta_info[0]), float(beta_info[1])]
     summary["gamma"] = [float(gamma_info[0]), float(gamma_info[1])]
 
-    # compute the score
+    # compute the score and add star rating
     risk = np.linspace(*summary["risk_bounds"], 100)
     signal = get_signal(signal_model, risk)
     beta_sd = np.sqrt(beta_info[1] ** 2 + gamma_info[0] + 2 * gamma_info[1])
@@ -412,10 +412,25 @@ def get_linear_model_summary(
     sign = np.sign(pred)
     if np.any(np.prod(inner_ui[:, index], axis=0) < 0):
         summary["score"] = float("nan")
+        summary["star_rating"] = 0
     else:
-        summary["score"] = float(
+        score = float(
             ((sign * burden_of_proof)[:, index].mean(axis=1)).min()
         )
+        summary["score"] = score
+        #Assign star rating based on ROS
+        if np.isnan(score):
+            summary["star_rating"] = 0
+        elif score > np.log(1 + 0.85):
+            summary["star_rating"] = 5
+        elif score > np.log(1 + 0.50):
+            summary["star_rating"] = 4
+        elif score > np.log(1 + 0.15):
+            summary["star_rating"] = 3
+        elif score > 0:
+            summary["star_rating"] = 2
+        else:
+            summary["star_rating"] = 1
 
     # compute the publication bias
     index = df.is_outlier == 0

--- a/src/bopforge/dichotomous_pipeline/__main__.py
+++ b/src/bopforge/dichotomous_pipeline/__main__.py
@@ -55,6 +55,7 @@ def fit_signal_model(result_folder: Path) -> None:
         Data interface in charge of file reading and writing.
 
     """
+    pre_processing(result_folder)
     dataif = DataInterface(result=result_folder)
     name = dataif.result.name
 
@@ -204,7 +205,6 @@ def run(
         dataif.dump_o_dir(pair_settings, pair, "settings.yaml")
 
         np.random.seed(pair_settings["seed"])
-        pre_processing(pair_o_dir)
         for action in actions:
             globals()[action](pair_o_dir)
 

--- a/src/bopforge/dichotomous_pipeline/functions.py
+++ b/src/bopforge/dichotomous_pipeline/functions.py
@@ -235,7 +235,7 @@ def get_linear_model_summary(
     summary["beta"] = [float(beta_info[0]), float(beta_info[1])]
     summary["gamma"] = [float(gamma_info[0]), float(gamma_info[1])]
 
-    # compute the score
+    # compute the score and add star rating
     beta_sd = np.sqrt(beta_info[1] ** 2 + gamma_info[0] + 2 * gamma_info[1])
     sign = np.sign(beta_info[0])
     inner_ui = beta_info[0] - sign * 1.96 * beta_info[1]
@@ -243,8 +243,23 @@ def get_linear_model_summary(
 
     if inner_ui * beta_info[0] < 0:
         summary["score"] = float("nan")
+        summary["star_rating"] = 0
     else:
-        summary["score"] = float(0.5 * sign * burden_of_proof)
+        score = float(0.5 * sign * burden_of_proof)
+        summary["score"] = score
+        #Assign star rating based on ROS
+        if np.isnan(score):
+            summary["star_rating"] = 0
+        elif score > np.log(1 + 0.85):
+            summary["star_rating"] = 5
+        elif score > np.log(1 + 0.50):
+            summary["star_rating"] = 4
+        elif score > np.log(1 + 0.15):
+            summary["star_rating"] = 3
+        elif score > 0:
+            summary["star_rating"] = 2
+        else:
+            summary["star_rating"] = 1
 
     # compute the publication bias
     index = df.is_outlier == 0


### PR DESCRIPTION
Updates:

* Fix the plotting bug for when using `normalize_to_tmrel: true`. Data move with the curve correctly now
* Fix the issue where majority of the alternative exposure is less than the reference exposure yield `nan` score. We automatically sort the alternative and reference exposure, so that that interval where the score will be evaluated will never be empty.
* Change the uncertainty in the continuous pipeline to show 95% CI and explicitly plot BPRF.
* Add option to allow user turn off the line segment between alternative and reference data points. This option is in the new `figure` section.
* Add star-rating to the`summary.yaml` file