### PR TITLE
Add performance metric to summary file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,15 @@ license = { file = "LICENSE" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },
 ]
-dependencies = ["numpy", "scipy", "pandas", "matplotlib", "mrtool==0.1.4", "pplkit"]
+dependencies = [
+    "numpy",
+    "scipy",
+    "pandas",
+    "matplotlib",
+    "limetr @ git+https://github.com/zhengp0/limetr.git@0.0.8",
+    "mrtool==0.1.4",
+    "pplkit",
+]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/src/bopforge/continuous_pipeline/__main__.py
+++ b/src/bopforge/continuous_pipeline/__main__.py
@@ -65,7 +65,7 @@ def fit_signal_model(dataif: DataInterface) -> None:
 
     df = functions.convert_bc_to_em(df, signal_model)
 
-    summary = functions.get_signal_model_summary(name, all_settings, df)
+    summary = functions.get_signal_model_summary(name, all_settings, df, signal_model)
 
     fig = functions.plot_signal_model(
         name,

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -414,11 +414,9 @@ def get_linear_model_summary(
         summary["score"] = float("nan")
         summary["star_rating"] = 0
     else:
-        score = float(
-            ((sign * burden_of_proof)[:, index].mean(axis=1)).min()
-        )
+        score = float(((sign * burden_of_proof)[:, index].mean(axis=1)).min())
         summary["score"] = score
-        #Assign star rating based on ROS
+        # Assign star rating based on ROS
         if np.isnan(score):
             summary["star_rating"] = 0
         elif score > np.log(1 + 0.85):

--- a/src/bopforge/dichotomous_pipeline/functions.py
+++ b/src/bopforge/dichotomous_pipeline/functions.py
@@ -6,6 +6,7 @@ from matplotlib.pyplot import Axes, Figure
 from mrtool import MRBRT, CovFinder, LinearCovModel, MRData
 from pandas import DataFrame
 from scipy.stats import norm
+from limetr import get_aic, get_bic, get_rmse
 
 
 def get_signal_model(settings: dict, df: DataFrame) -> MRBRT:
@@ -271,6 +272,14 @@ def get_linear_model_summary(
     pval = 1 - norm.cdf(np.abs(r_mean / r_sd))
     summary["pub_bias"] = int(pval < 0.05)
     summary["pub_bias_pval"] = float(pval)
+
+    summary["model_performance"] = {
+        "linear_model": {
+            "aic": float(get_aic(linear_model.lt)),
+            "bic": float(get_bic(linear_model.lt)),
+            "rmse": float(get_rmse(linear_model.lt)),
+        }
+    }
 
     return summary
 


### PR DESCRIPTION
Add `aic`, `bic` and `rmse` of models to the summary file.
The score is computed in the `limetr` level, here we will use `limetr` version
https://github.com/zhengp0/limetr/tree/0.0.8