### PR TITLE
Adjustments to settings

### DIFF
--- a/data/categorical/settings.yaml
+++ b/data/categorical/settings.yaml
@@ -30,12 +30,3 @@ default:
       num_draws: 1000
       # additional quantiles for accurate estimation of quantiles rather than rely on draws
       quantiles: [0.025, 0.05, 0.5, 0.95, 0.975]
-    score:
-      # if we normalize the risk 'curve' to the lowest log RR
-      # only for j-shaped this can be true
-      # NOTE: shape will be dependent on plotting order (i.e., could artificially end up with a j-shaped curve, 
-      # as risk exposure categories do not increase in a fixed order, unlike continuous risk exposure values)
-      normalize_to_tmrel: false
-  figure:
-    # show line connecting alternative and reference datapoints
-    show_ref: true

--- a/src/bopforge/categorical_pipeline/__main__.py
+++ b/src/bopforge/categorical_pipeline/__main__.py
@@ -47,6 +47,21 @@ def pre_processing(result_folder: Path) -> None:
     # Add design matrices for interacted model covariates to data
     df = functions.covariate_design_mat(df, all_settings)
 
+    # Validate ordering constraints if categories are ordinal
+    cat_order = all_settings["cat_order"]
+    prior_order = all_settings["fit_signal_model"]["cat_cov_model"][
+        "prior_order"
+    ]
+    # Check cat_order is complete
+    functions._validate_cat_order(cat_order, unique_cats)
+    # For ordinal categories, fill in prior_order from cat_order if not provided
+    prior_order = functions._validate_cat_order_prior_order_match(
+        cat_order, prior_order
+    )
+    all_settings["fit_signal_model"]["cat_cov_model"]["prior_order"] = (
+        prior_order
+    )
+
     # save results
     dataif.dump_result(df, f"{name}.csv")
     dataif.dump_result(all_settings, "settings.yaml")


### PR DESCRIPTION
- Removed normalize_to_tmrel and show_ref settings for categorical pipeline as they are not relevant
- Linked cat_order and prior_order settings for ordinal categories
- Shifted validation of cat_order to pre-processing
- If cat_order is provided and complete and if prior_order is also provided validate that these two settings match. If prior_order not provided, then fill with cat_order.
- If cat_order is not provided, prior_order is unchanged.
- Re-dump prior_order (unchanged or updated based on cat_order) to settings in pre-processing for easier usage in signal and linear models.