### PR TITLE
Feature/linear extrapolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bopforge"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pipelines for Burden of Proof (BoP) analyses"
 readme = "REDME.md"
 requires-python = ">=3.10"

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -496,8 +496,14 @@ def get_draws(
         risk_upper = summary["risk_bounds"][1]
     else:
         risk_upper = settings["draws"]["risk_upper"]
-    risk = np.linspace(risk_lower, risk_upper, settings["draws"]["num_points"])
-    signal = get_signal(signal_model, risk)
+    num_points = settings["draws"]["num_points"]
+    risk = np.linspace(risk_lower, risk_upper, num_points)
+    risk_from_data = np.linspace(*summary["risk_bounds"], num_points)
+    signal_from_data = get_signal(signal_model, risk_from_data)
+    # Build interpolator with linear extrapolation
+    signal_interp = make_interp_spline(risk_from_data, signal_from_data, k=1)
+    # Calculate extrapolated signal
+    signal = signal_interp(risk)
     inner_beta_sd = summary["beta"][1]
     outer_beta_sd = np.sqrt(
         summary["beta"][1] ** 2 + summary["gamma"][0] + 2 * summary["gamma"][1]


### PR DESCRIPTION
Add linear extrapolation to draws and quantiles generation so that if modelers specify an exposure range different from the range found in the data, the draws and quantiles are generated using the original prediction over the data-supported exposure range and by using linear extrapolation at the extrapolated tails.