### PR TITLE
Feature/trimming count

### DIFF
--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -126,7 +126,18 @@ def convert_bc_to_em(df: DataFrame, signal_model: MRBeRT) -> DataFrame:
             }
         )
     )
-    is_outlier = (signal_model.w_soln < 0.1).astype(int)
+
+    inlier_pct = signal_model.inlier_pct
+    target_outlier_count = int(np.round((1.0 - inlier_pct) * data.num_obs))
+    is_outlier_arr = (signal_model.w_soln < 0.1).astype(int)
+    current_outlier_count = np.sum(is_outlier_arr)
+    if current_outlier_count < target_outlier_count:
+        num_to_add = target_outlier_count - current_outlier_count
+        inlier_indices = np.where(is_outlier_arr == 0)[0]
+        additional_outlier_indices = np.argsort(signal_model.w_soln[inlier_indices])[:num_to_add]
+        is_outlier_arr[inlier_indices[additional_outlier_indices]] = 1
+    is_outlier = is_outlier_arr
+    # is_outlier = (signal_model.w_soln < 0.1).astype(int)
     df = df.merge(
         pd.DataFrame(
             {

--- a/src/bopforge/continuous_pipeline/functions.py
+++ b/src/bopforge/continuous_pipeline/functions.py
@@ -128,7 +128,7 @@ def convert_bc_to_em(df: DataFrame, signal_model: MRBeRT) -> DataFrame:
     )
 
     inlier_pct = signal_model.inlier_pct
-    target_outlier_count = int(np.round((1.0 - inlier_pct) * data.num_obs))
+    target_outlier_count = int(np.ceil((1.0 - inlier_pct) * data.num_obs))
     is_outlier_arr = (signal_model.w_soln < 0.1).astype(int)
     current_outlier_count = np.sum(is_outlier_arr)
     if current_outlier_count < target_outlier_count:
@@ -137,7 +137,6 @@ def convert_bc_to_em(df: DataFrame, signal_model: MRBeRT) -> DataFrame:
         additional_outlier_indices = np.argsort(signal_model.w_soln[inlier_indices])[:num_to_add]
         is_outlier_arr[inlier_indices[additional_outlier_indices]] = 1
     is_outlier = is_outlier_arr
-    # is_outlier = (signal_model.w_soln < 0.1).astype(int)
     df = df.merge(
         pd.DataFrame(
             {


### PR DESCRIPTION
Add trimming count to ensure we always trim outlier_pct = (1 - inlier_pct)*100% of datapoints in the continuous model. If submodels do not agree and fewer than outlier_pct of points fall below the w_soln < 0.1 threshold, this guarantees we still trim outlier_pct of datapoints. Using slightly more aggressive ceiling strategy to round up to nearest integer of points to trim to be consistent with the number of inliers being set with floor at the limetr level.

Note: needs eventual version bump.

If there are any suggestions for how to handle the extra outlier identification better/more safely that doesn't use indexing, happy to incorporate those!